### PR TITLE
Format source, add import_path and fix circular imports

### DIFF
--- a/gengo/generate.go
+++ b/gengo/generate.go
@@ -167,7 +167,7 @@ func (m *{{ .ShortName }}) Deserialize(buf *bytes.Reader) error {
                 if err = binary.Read(buf, binary.LittleEndian, data); err != nil {
                     return err
                 }
-                m.{{ .GoName }})[i] = string(data)
+                m.{{ .GoName }}[i] = string(data)
             }
 {{-              else }}
 {{- 					if or (eq .Type "time") (eq .Type "duration") }}
@@ -306,6 +306,11 @@ OUTER:
 				}
 			}
 			gen.Imports = append(gen.Imports, imp_path+field.Package)
+		}
+
+		// Binary is required to read the size of array
+		if field.IsArray {
+			gen.BinaryRequired = true
 		}
 	}
 }

--- a/gengo/main.go
+++ b/gengo/main.go
@@ -28,7 +28,7 @@ func writeCode(fullname string, code string) error {
 
 	res, err := format.Source([]byte(code))
 	if err != nil {
-		return err
+		return fmt.Errorf("Error formatting generated code: %+v", err)
 	}
 
 	return ioutil.WriteFile(filename, res, os.FileMode(0664))

--- a/gengo/main.go
+++ b/gengo/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"go/format"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -10,7 +11,8 @@ import (
 )
 
 var (
-	out = flag.String("out", "vendor", "Directory to generate files to")
+	out         = flag.String("out", "vendor", "Directory to generate files in")
+	import_path = flag.String("import_path", "", "Specify import path/prefix for nested types")
 )
 
 func writeCode(fullname string, code string) error {
@@ -24,7 +26,12 @@ func writeCode(fullname string, code string) error {
 	}
 	filename := filepath.Join(pkgDir, nameComponents[1]+".go")
 
-	return ioutil.WriteFile(filename, []byte(code), os.FileMode(0664))
+	res, err := format.Source([]byte(code))
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filename, res, os.FileMode(0664))
 }
 
 func main() {
@@ -38,7 +45,7 @@ func main() {
 	}
 
 	if flag.NArg() < 2 {
-		fmt.Println("USAGE: gengo [-out=] msg|srv <NAME> [<FILE>]")
+		fmt.Println("USAGE: gengo [-out=] [-import_path=] msg|srv <NAME> [<FILE>]")
 		os.Exit(-1)
 	}
 


### PR DESCRIPTION
Description:
- Add import_path flag that allows nested imports of packages from locations other than the vendor.
- Skip importing if field package and generated package are same.
- Format the output source although not sure if this is a good idea.
