### PR TITLE
Preventing panic in tests and a better Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
-rosgo
-============================================================================
-[![GoDoc](https://godoc.org/github.com/fetchrobotics/rosgo?status.svg)](https://godoc.org/github.com/fetchrobotics/rosgo) 
-[![Build Status](https://travis-ci.org/fetchrobotics/rosgo.svg?branch=master)](https://travis-ci.org/fetchrobotics/rosgo)
+## rosgo
 
-Package Summary
----------------------------------
+[![GoDoc](https://godoc.org/github.com/fetchrobotics/rosgo?status.svg)](https://godoc.org/github.com/fetchrobotics/rosgo) 
+[![Build Status](https://travis-ci.com/akio/rosgo.svg?branch=master)](https://travis-ci.com/akio/rosgo)
+
+## Package Summary
 
 **rosgo** is pure Go implementation of [ROS](http://www.ros.org/) client library.
 
 - Author: Akio Ochiai
+- Maintainer: Fetch Robotics
 - License: Apache License 2.0
 - Source: git [https://github.com/akio/rosgo](https://github.com/akio/rosgo)
+- ROS Version Support: [Indigo] [Jade] [Melodic]
 
-Status
----------------------------------
+## Prerequisites
+
+To use this library you should have installed ROS: [Install](wiki.ros.org/melodic/Installation/Ubuntu).
+To run the tests please install all sensor msgs: `sudo apt install ros-melodic-desktop-full` for Ubuntu
+
+## Status
 
 **rosgo** is under development to implement all features of [ROS Client Library Requiements](http://www.ros.org/wiki/Implementing%20Client%20Libraries).
 
@@ -25,8 +30,18 @@ At present, following basic functions are provided.
 - Remapping
 - Message Generation
 
+Work to do:
 
-See also
----------------------------------
+- Action Servers
+- Go Module Support
+- Tutorials
+- Bus Statistics
+- ROS 2 Support
+
+## How to use
+
+Please look in the [test](test) folder for how to use rosgo in your projects.
+
+## See also
 
 - [rosgo in ROS Wiki](http://www.ros.org/wiki/rosgo)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - Author: Akio Ochiai
 - Maintainer: Fetch Robotics
 - License: Apache License 2.0
-- Source: git [https://github.com/akio/rosgo](https://github.com/akio/rosgo)
+- Source: git [https://github.com/fetchrobotics/rosgo](https://github.com/fetchrobotics/rosgo)
 - ROS Version Support: [Indigo] [Jade] [Melodic]
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## rosgo
 
 [![GoDoc](https://godoc.org/github.com/fetchrobotics/rosgo?status.svg)](https://godoc.org/github.com/fetchrobotics/rosgo) 
-[![Build Status](https://travis-ci.com/fetchrobotics/rosgo.svg?branch=master)](https://travis-ci.com/fetchrobotics/rosgo)
+[![Build Status](https://travis-ci.org/fetchrobotics/rosgo.svg?branch=master)](https://travis-ci.org/fetchrobotics/rosgo)
 
 ## Package Summary
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## rosgo
 
 [![GoDoc](https://godoc.org/github.com/fetchrobotics/rosgo?status.svg)](https://godoc.org/github.com/fetchrobotics/rosgo) 
-[![Build Status](https://travis-ci.com/akio/rosgo.svg?branch=master)](https://travis-ci.com/akio/rosgo)
+[![Build Status](https://travis-ci.com/fetchrobotics/rosgo.svg?branch=master)](https://travis-ci.com/fetchrobotics/rosgo)
 
 ## Package Summary
 

--- a/gengo/parser_test.go
+++ b/gengo/parser_test.go
@@ -171,20 +171,21 @@ func TestMD5_std_msgs(t *testing.T) {
 	ctx, e := NewMsgContext(strings.Split(rosPkgPath, ":"))
 	if e != nil {
 		t.Errorf("Failed to create MsgContext.")
-	}
+	} else {
+		for fullname, md5 := range std_msgs {
+			_, shortName, _ := packageResourceName(fullname)
 
-	for fullname, md5 := range std_msgs {
-		_, shortName, _ := packageResourceName(fullname)
+			t.Run(shortName, func(t *testing.T) {
+				var spec *MsgSpec
+				spec, e := ctx.LoadMsg(fullname)
+				if e != nil {
+					t.Errorf("Failed to parse: %v", e)
+				} else {
+					assertEqual(t, spec.MD5Sum, md5)
+				}
+			})
+		}
 
-		t.Run(shortName, func(t *testing.T) {
-			var spec *MsgSpec
-			spec, e := ctx.LoadMsg(fullname)
-			if e != nil {
-				t.Errorf("Failed to parse: %v", e)
-			}
-
-			assertEqual(t, spec.MD5Sum, md5)
-		})
 	}
 }
 
@@ -233,9 +234,9 @@ func TestMD5_sensor_msgs(t *testing.T) {
 			spec, e := ctx.LoadMsg(fullname)
 			if e != nil {
 				t.Errorf("Failed to parse: %v", e)
+			} else {
+				assertEqual(t, spec.MD5Sum, md5)
 			}
-
-			assertEqual(t, spec.MD5Sum, md5)
 		})
 	}
 }


### PR DESCRIPTION
This fixes an error in the tests where they would panic if you didn't have the right messages installed on your machine.


Old return on `go test`
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x54fcac]

goroutine 52 [running]:
testing.tRunner.func1(0xc00018c300)
        /usr/local/go/src/testing/testing.go:792 +0x387
panic(0x57fb80, 0x6e9060)
        /usr/local/go/src/runtime/panic.go:513 +0x1b9
rosgo/gengo.TestMD5_sensor_msgs.func1(0xc00018c300)
        /home/cjds/ws/src/rosgo/gengo/parser_test.go:239 +0xdc
testing.tRunner(0xc00018c300, 0xc00017c7e0)
        /usr/local/go/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:878 +0x35c
exit status 2
FAIL    rosgo/gengo     0.063s
```

New return
```
    --- FAIL: TestMD5_sensor_msgs/PointField (0.00s)
        parser_test.go:236: Failed to parse: Message definition of `sensor_msgs/PointField` is not found
    --- FAIL: TestMD5_sensor_msgs/Image (0.00s)
        parser_test.go:236: Failed to parse: Message definition of `sensor_msgs/Image` is not found
    --- FAIL: TestMD5_sensor_msgs/JoyFeedbackArray (0.00s)
        parser_test.go:236: Failed to parse: Message definition of `sensor_msgs/JoyFeedbackArray` is not found
    --- FAIL: TestMD5_sensor_msgs/MagneticField (0.00s)
        parser_test.go:236: Failed to parse: Message definition of `sensor_msgs/MagneticField` is not found
    --- FAIL: TestMD5_sensor_msgs/JoyFeedback (0.00s)
        parser_test.go:236: Failed to parse: Message definition of `sensor_msgs/JoyFeedback` is not found
    --- FAIL: TestMD5_sensor_msgs/LaserScan (0.00s)
        parser_test.go:236: Failed to parse: Message definition of `sensor_msgs/LaserScan` is not found
    --- FAIL: TestMD5_sensor_msgs/Temperature (0.00s)
        parser_test.go:236: Failed to parse: Message definition of `sensor_msgs/Temperature` is not found
    --- FAIL: TestMD5_sensor_msgs/LaserEcho (0.00s)
        parser_test.go:236: Failed to parse: Message definition of `sensor_msgs/LaserEcho` is not found
    --- FAIL: TestMD5_sensor_msgs/MultiDOFJointState (0.00s)
        parser_test.go:236: Failed to parse: Message definition of `sensor_msgs/MultiDOFJointState` is not found
    --- FAIL: TestMD5_sensor_msgs/Range (0.00s)
        parser_test.go:236: Failed to parse: Message definition of `sensor_msgs/Range` is not found

```