### PR TITLE
Remove Go version 1.6, 1.7, 1.8 and add 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: go
 
 go:
-    - "1.6"
-    - "1.7"
-    - "1.8"
     - "1.9"
     - "1.10"
     - "1.11"
+    - "1.12"
 
 env:
     - ROS_DOCKER=ros:kinetic-ros-base


### PR DESCRIPTION
Removes support for 1.6, 1.7 and 1.8 since sync.Map is only available in versions > 1.9. 