### PR TITLE
Fix shutdown order

### DIFF
--- a/ros/node.go
+++ b/ros/node.go
@@ -466,15 +466,15 @@ func (node *defaultNode) Shutdown() {
 		s.Shutdown()
 	}
 	node.logger.Debug("Shutdown servers...done")
+	node.logger.Debug("Wait all goroutines")
+	node.waitGroup.Wait()
+	node.logger.Debug("Wait all goroutines...Done")
 	node.logger.Debug("Close XMLRPC lisetner")
 	node.xmlrpcListener.Close()
 	node.logger.Debug("Close XMLRPC done")
 	node.logger.Debug("Wait XMLRPC server shutdown")
 	node.xmlrpcHandler.WaitForShutdown()
 	node.logger.Debug("Wait XMLRPC server shutdown...Done")
-	node.logger.Debug("Wait all goroutines")
-	node.waitGroup.Wait()
-	node.logger.Debug("Wait all goroutines...Done")
 	node.logger.Debug("Shutting node down completed")
 	return
 }


### PR DESCRIPTION
When shutting down a node, XMLRPC connection must be closed *after* all goroutines have finished, because some goroutines call ROS api in the shutdown process (e.g. `unregisterSubscriber` and `unregisterService`).