### PR TITLE
Add anytopic support for subscriber

### DIFF
--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -182,9 +182,17 @@ func startRemotePublisherConn(logger Logger,
 		resHeaderMap[h.key] = h.value
 		logger.Debugf("  `%s` = `%s`", h.key, h.value)
 	}
-	if resHeaderMap["type"] != msgType || resHeaderMap["md5sum"] != md5sum {
-		logger.Fatalf("Incomatible message type!")
+
+	if resHeaderMap["type"] != msgType && resHeaderMap["type"] != "*" {
+		panic(fmt.Errorf("incompatible message type: type does not match for topic %s: %s vs %s",
+			topic, msgType, resHeaderMap["type"]))
 	}
+
+	if resHeaderMap["name"] != msgType && resHeaderMap["name"] != "*" {
+		panic(fmt.Errorf("incompatible message name: name does not match for topic %s: %s vs %s",
+			topic, msgType, resHeaderMap["name"]))
+	}
+
 	logger.Debug("Start receiving messages...")
 	event := MessageEvent{ // Event struct to be sent with each message.
 		PublisherName:    resHeaderMap["callerid"],


### PR DESCRIPTION
Updated subscriber MessageType and MessageName to allow specifying `*` which can be used to subscribe to any type by creating a message similar to this. This way, we can choose to get raw message bytes instead of the deserialized message. 

Example AnyMsg implementation in python is here:
https://github.com/ros/ros_comm/blob/5da095d06bccbea708394b399215d8a066797266/clients/rospy/src/rospy/msg.py#L48