### PR TITLE
Rename Type() method and prefix message type to constants' name

### DIFF
--- a/gengo/generate.go
+++ b/gengo/generate.go
@@ -24,9 +24,9 @@ import (
 const (
 {{- range .Constants }}
 	{{- if eq .Type "string" }}
-    {{ .GoName }} {{ .Type }} = "{{ .Value }}"
+    {{ $.ShortName }}_{{ .GoName }} {{ .Type }} = "{{ .Value }}"
 	{{- else }}
-	{{ .GoName }} {{ .Type }} = {{ .Value }}
+	{{ $.ShortName }}_{{ .GoName }} {{ .Type }} = {{ .Value }}
 	{{- end }}
 {{- end }}
 )
@@ -91,7 +91,7 @@ type {{ .ShortName }} struct {
 {{- end }}
 }
 
-func (m *{{ .ShortName }}) Type() ros.MessageType {
+func (m *{{ .ShortName }}) GetType() ros.MessageType {
 	return Msg{{ .ShortName }}
 }
 

--- a/gengo/msgs.go
+++ b/gengo/msgs.go
@@ -216,7 +216,11 @@ func ToGoType(pkg string, typeName string) string {
 	return goType
 }
 
-func ToGoName(name string) string {
+func ToGoName(name string, constant bool) string {
+	if constant {
+		return strings.ToUpper(name)
+	}
+
 	var buffer []string
 	words := strings.Split(name, "_")
 	for _, word := range words {
@@ -272,7 +276,7 @@ func GetZeroValue(pkg string, typeName string) string {
 }
 
 func NewConstant(fieldType string, name string, value interface{}, valueText string) *Constant {
-	goName := ToGoName(name)
+	goName := ToGoName(name, true)
 	return &Constant{fieldType, name, value, valueText, goName}
 }
 
@@ -294,7 +298,7 @@ type Field struct {
 
 func NewField(pkg string, fieldType string, name string, isArray bool, arrayLen int) *Field {
 	goType := ToGoType(pkg, fieldType)
-	goName := ToGoName(name)
+	goName := ToGoName(name, false)
 	zeroValue := GetZeroValue(pkg, fieldType)
 	isBuiltin := isBuiltinType(fieldType)
 	return &Field{pkg, fieldType, name, isBuiltin, isArray, arrayLen, goName, goType, zeroValue}

--- a/ros/message.go
+++ b/ros/message.go
@@ -12,7 +12,7 @@ type MessageType interface {
 }
 
 type Message interface {
-	Type() MessageType
+	GetType() MessageType
 	Serialize(buf *bytes.Buffer) error
 	Deserialize(buf *bytes.Reader) error
 }


### PR DESCRIPTION
Fixes issue https://github.com/fetchrobotics/rosgo/issues/29

- Renamed Type() method to GetType() in the message template
- Added MessageType prefix to constants to avoid redeclaration errors when two messages have the same constant name within a package.

Tested with internal messages that have `Type` field and same named constants within the same package.