### PR TITLE
Fix error returns in gengo and make subscriber consistent with roscpp Impl

### DIFF
--- a/gengo/context.go
+++ b/gengo/context.go
@@ -139,8 +139,10 @@ func (ctx *MsgContext) LoadMsgFromString(text string, fullname string) (*MsgSpec
 			fields = append(fields, *field)
 		}
 	}
-	spec, _ := NewMsgSpec(fields, constants, text, fullname, OptionPackageName(packageName), OptionShortName(shortName))
-	var err error
+	spec, err := NewMsgSpec(fields, constants, text, fullname, OptionPackageName(packageName), OptionShortName(shortName))
+	if err != nil {
+		return nil, err
+	}
 	md5sum, err := ctx.ComputeMsgMD5(spec)
 	if err != nil {
 		return nil, err
@@ -245,11 +247,11 @@ func (ctx *MsgContext) ComputeMD5Text(spec *MsgSpec) (string, error) {
 		} else {
 			subspec, err := ctx.LoadMsg(f.Package + "/" + f.Type)
 			if err != nil {
-				return "", nil
+				return "", err
 			}
 			submd5, err := ctx.ComputeMsgMD5(subspec)
 			if err != nil {
-				return "", nil
+				return "", err
 			}
 			buf.WriteString(fmt.Sprintf("%s %s\n", submd5, f.Name))
 		}

--- a/gengo/context.go
+++ b/gengo/context.go
@@ -139,10 +139,8 @@ func (ctx *MsgContext) LoadMsgFromString(text string, fullname string) (*MsgSpec
 			fields = append(fields, *field)
 		}
 	}
-	spec, err := NewMsgSpec(fields, constants, text, fullname, OptionPackageName(packageName), OptionShortName(shortName))
-	if err != nil {
-		return nil, err
-	}
+	spec, _ := NewMsgSpec(fields, constants, text, fullname, OptionPackageName(packageName), OptionShortName(shortName))
+	var err error
 	md5sum, err := ctx.ComputeMsgMD5(spec)
 	if err != nil {
 		return nil, err
@@ -247,11 +245,11 @@ func (ctx *MsgContext) ComputeMD5Text(spec *MsgSpec) (string, error) {
 		} else {
 			subspec, err := ctx.LoadMsg(f.Package + "/" + f.Type)
 			if err != nil {
-				return "", err
+				return "", nil
 			}
 			submd5, err := ctx.ComputeMsgMD5(subspec)
 			if err != nil {
-				return "", err
+				return "", nil
 			}
 			buf.WriteString(fmt.Sprintf("%s %s\n", submd5, f.Name))
 		}

--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -183,10 +183,6 @@ func startRemotePublisherConn(logger Logger,
 		logger.Debugf("  `%s` = `%s`", h.key, h.value)
 	}
 
-	if msgType != resHeaderMap["type"] && msgType != "*" {
-		panic("incompatible message type: message type mismatch")
-	}
-
 	if md5sum != resHeaderMap["md5sum"] && md5sum != "*" {
 		panic("incompatible message type: md5sum mismatch")
 	}


### PR DESCRIPTION
- ~~Fixed error returns in gengo to prevent it from silently failing~~ Will add as a separate PR.
- Roscpp implementation allows subscribing to a topic with a different message name but the same md5sum. Removed type check in subscriber.go to make it consistent with roscpp implementation.