### PR TITLE
Fix deadlock on server shutdown

### DIFF
--- a/ros/service_server.go
+++ b/ros/service_server.go
@@ -151,6 +151,7 @@ func newRemoteClientSession(s *defaultServiceServer, conn net.Conn) *remoteClien
 	session := new(remoteClientSession)
 	session.server = s
 	session.conn = conn
+	session.quitChan = make(chan struct{}, 1)
 	session.responseChan = make(chan []byte)
 	session.errorChan = make(chan error)
 	return session
@@ -303,6 +304,8 @@ func (s *remoteClientSession) start() {
 		if _, err := conn.Write([]byte(errMsg)); err != nil {
 			panic(err)
 		}
+	case <-s.quitChan:
+		s.errorChan <- fmt.Errorf("service shut down")
 	case <-timeoutChan:
 		panic(fmt.Errorf("service callback timeout"))
 	}


### PR DESCRIPTION
On shutdown, a service server is supposed to quit all active sessions,
but until this change, the sessions wouldn't get the message: their
quitChan was always null (not initialized in newRemoteClientSession).