### PR TITLE
Allow to re-subscribe to a topic

### DIFF
--- a/ros/node.go
+++ b/ros/node.go
@@ -386,7 +386,11 @@ func (node *defaultNode) NewSubscriber(topic string, msgType MessageType, callba
 		node.subscribers[name] = sub
 
 		logger.Debugf("Start subscriber goroutine for topic '%s'", sub.topic)
-		go sub.start(&node.waitGroup, node.qualifiedName, node.xmlrpcURI, node.masterURI, node.jobChan, logger)
+		go sub.start(&node.waitGroup, node.qualifiedName, node.xmlrpcURI, node.masterURI, node.jobChan, logger, func() {
+			node.subscribersMutex.Lock()
+			defer node.subscribersMutex.Unlock()
+			delete(node.subscribers, name)
+		})
 		logger.Debugf("Done")
 		sub.pubListChan <- publishers
 		logger.Debugf("Update publisher list for topic '%s'", sub.topic)

--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -45,7 +45,7 @@ func newDefaultSubscriber(topic string, msgType MessageType, callback interface{
 	return sub
 }
 
-func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeURI string, masterURI string, jobChan chan func(), logger Logger) {
+func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeURI string, masterURI string, jobChan chan func(), logger Logger, unregisterFromNode func()) {
 	logger.Debugf("Subscriber goroutine for %s started.", sub.topic)
 	wg.Add(1)
 	defer wg.Done()
@@ -140,6 +140,8 @@ func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeURI s
 			if err != nil {
 				logger.Warn(err)
 			}
+
+			unregisterFromNode()
 			return
 		}
 	}


### PR DESCRIPTION
There is a bug in rosgo where once a subscriber for a topic is shutdown, no new
subscribers for the same topic would function.  The problem is that shutting
down a subscriber will unregister the subscriber from the master, but wouldn't
update node.subscribers map keeping track of active subscribers. So next
subscribers to the same topic only add a callback to a now defunkt subscriber.

This CL passes a callback to the subscriber to remove itself from the node on
the shutdown.  I chose to use a callback instead of using channels, because
spinning up another goroutine for subscriber management seemed like an overkill
for this particular task.