### PR TITLE
No-copy deserialization of byte arrays

### DIFF
--- a/ros/message.go
+++ b/ros/message.go
@@ -14,5 +14,5 @@ type MessageType interface {
 type Message interface {
 	GetType() MessageType
 	Serialize(buf *bytes.Buffer) error
-	Deserialize(buf *bytes.Reader) error
+	Deserialize(buf *Reader) error
 }

--- a/ros/serialization.go
+++ b/ros/serialization.go
@@ -1,0 +1,48 @@
+package ros
+
+import (
+	"io"
+)
+
+// Reader implements io.Reader interface and provides a no-copy way to read N
+// bytes via Next() method. Reader is used by generated message to de-serialize
+// byte arrays ([]uint8) without/ copying underlying data.
+type Reader struct {
+	s []byte
+	i int
+}
+
+// NewReader creates new Reader and adopts the byte slice.
+// The caller must not modify the slice after this call.
+func NewReader(s []byte) *Reader {
+	return &Reader{s, 0}
+}
+
+// Read implements the io.Reader interface. Like the other reader
+// implementations, this implementation copies data from the original slice
+// into "b".
+func (r *Reader) Read(b []byte) (n int, err error) {
+	if r.i >= len(r.s) {
+		return 0, io.EOF
+	}
+	n = copy(b, r.s[r.i:])
+	r.i += n
+	return
+}
+
+// Next returns a slice containing the next n bytes from the buffer, advancing
+// the buffer as if the bytes had been returned by Read. The resulting slice is
+// a sub-slice of the original slice.
+//
+// Asking for more bytes than available would returns only the remaining bytes.
+// Calling Next on an empty buffer, or after the buffer has been exhausted,
+// returns an empty slice.
+func (r *Reader) Next(n int) []byte {
+	m := len(r.s) - r.i
+	if n > m {
+		n = m
+	}
+	data := r.s[r.i : r.i+n]
+	r.i += n
+	return data
+}

--- a/ros/serialization_test.go
+++ b/ros/serialization_test.go
@@ -1,0 +1,176 @@
+package ros
+
+import (
+	"io"
+	"testing"
+
+	"google3/third_party/golang/cmp/cmp"
+)
+
+func TestReader(t *testing.T) {
+	type nextOp struct {
+		n    int
+		want []byte
+	}
+	type readOp struct {
+		buffer  []byte
+		want    []byte
+		wantN   int
+		wantErr error
+	}
+	type op struct {
+		read *readOp
+		next *nextOp
+	}
+
+	for _, tc := range []struct {
+		name string
+		data []byte
+		ops  []op
+	}{
+		{
+			name: "ReadAll",
+			data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
+			ops: []op{
+				{read: &readOp{
+					buffer: make([]byte, 8),
+					want:   []byte{1, 2, 3, 4, 5, 6, 7, 8},
+					wantN:  8,
+				}},
+				{read: &readOp{
+					buffer: make([]byte, 8),
+					want:   []byte{9, 10, 11, 12, 13, 14, 15, 16},
+					wantN:  8,
+				}},
+				{read: &readOp{
+					buffer: make([]byte, 16),
+					want:   []byte{17, 18, 19, 20, 21, 22, 23, 24, 0, 0, 0, 0, 0, 0, 0, 0},
+					wantN:  8,
+				}},
+				{read: &readOp{
+					buffer:  make([]byte, 1),
+					want:    []byte{0},
+					wantN:   0,
+					wantErr: io.EOF,
+				}},
+			},
+		},
+		{
+			name: "NextAll",
+			data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
+			ops: []op{
+				{next: &nextOp{
+					n:    8,
+					want: []byte{1, 2, 3, 4, 5, 6, 7, 8},
+				}},
+				{next: &nextOp{
+					n:    8,
+					want: []byte{9, 10, 11, 12, 13, 14, 15, 16},
+				}},
+				{next: &nextOp{
+					n:    16,
+					want: []byte{17, 18, 19, 20, 21, 22, 23, 24},
+				}},
+				{next: &nextOp{
+					n:    8,
+					want: []byte{},
+				}},
+			},
+		},
+		{
+			name: "ReadAndNextAll",
+			data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
+			ops: []op{
+				{read: &readOp{
+					buffer: make([]byte, 8),
+					want:   []byte{1, 2, 3, 4, 5, 6, 7, 8},
+					wantN:  8,
+				}},
+				{next: &nextOp{
+					n:    8,
+					want: []byte{9, 10, 11, 12, 13, 14, 15, 16},
+				}},
+				{read: &readOp{
+					buffer: make([]byte, 16),
+					want:   []byte{17, 18, 19, 20, 21, 22, 23, 24, 0, 0, 0, 0, 0, 0, 0, 0},
+					wantN:  8,
+				}},
+				{next: &nextOp{
+					n:    8,
+					want: []byte{},
+				}},
+			},
+		},
+		{
+			name: "ReadEmtpyBuffer",
+			data: []byte{},
+			ops: []op{
+				{read: &readOp{
+					buffer:  make([]byte, 1),
+					want:    []byte{0},
+					wantN:   0,
+					wantErr: io.EOF,
+				}},
+			},
+		},
+		{
+			name: "ReadEmtpyBufferEmptyRead",
+			data: []byte{},
+			ops: []op{
+				{read: &readOp{
+					buffer:  make([]byte, 0),
+					want:    []byte{},
+					wantN:   0,
+					wantErr: io.EOF,
+				}},
+			},
+		},
+		{
+			name: "NextEmtpyBuffer",
+			data: []byte{},
+			ops: []op{
+				{next: &nextOp{
+					n:    1,
+					want: []byte{},
+				}},
+			},
+		},
+		{
+			name: "NextEmtpyBufferZeroBytes",
+			data: []byte{},
+			ops: []op{
+				{next: &nextOp{
+					n:    0,
+					want: []byte{},
+				}},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewReader(tc.data)
+			for _, op := range tc.ops {
+				if op.read != nil {
+					n, err := r.Read(op.read.buffer)
+
+					if diff := cmp.Diff(op.read.want, op.read.buffer); diff != "" {
+						t.Errorf("Read(%v) read unexpected bytes: diff (-want +got): %v\nreader: %+v", op.read.buffer, diff, r)
+					}
+
+					if op.read.wantN != n {
+						t.Errorf("Read(%v) read unexpected number of bytes: got %v, want %v\nreader: %+v", op.read.buffer, n, op.read.wantN, r)
+					}
+
+					if op.read.wantErr != err {
+						t.Errorf("Read(%v) returned unexpected error: got %v, want %v\nreader: %+v", op.read.buffer, err, op.read.wantErr, r)
+					}
+				} else if op.next != nil {
+					got := r.Next(op.next.n)
+					if diff := cmp.Diff(op.next.want, got); diff != "" {
+						t.Errorf("Next(%v) returned unexpected bytes: diff (-want +got): %v\nreader: %+v", op.next.n, diff, r)
+					}
+				}
+			}
+		})
+	}
+}

--- a/ros/service_client.go
+++ b/ros/service_client.go
@@ -137,7 +137,7 @@ func (c *defaultServiceClient) Call(srv Service) error {
 	if _, err = io.ReadFull(conn, resBuffer); err != nil {
 		return err
 	}
-	resReader := bytes.NewReader(resBuffer)
+	resReader := NewReader(resBuffer)
 	if err := srv.ResMessage().Deserialize(resReader); err != nil {
 		return err
 	}

--- a/ros/service_server.go
+++ b/ros/service_server.go
@@ -236,7 +236,7 @@ func (s *remoteClientSession) start() {
 
 	s.server.node.jobChan <- func() {
 		srv := s.server.srvType.NewService()
-		reader := bytes.NewReader(resBuffer)
+		reader := NewReader(resBuffer)
 		err := srv.ReqMessage().Deserialize(reader)
 		if err != nil {
 			s.errorChan <- err

--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -1,7 +1,6 @@
 package ros
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -110,7 +109,7 @@ func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeURI s
 			copy(callbacks, sub.callbacks)
 			jobChan <- func() {
 				m := sub.msgType.NewMessage()
-				reader := bytes.NewReader(msgEvent.bytes)
+				reader := NewReader(msgEvent.bytes)
 				if err := m.Deserialize(reader); err != nil {
 					logger.Error(err)
 				}


### PR DESCRIPTION
This is necessary for deserializing large image blobs from the wire
without extra memory allocations.

The current implementation copies image data byte-by-byte, copying it
3 times in total: first by copying it off the wire, then by copying
it from the bytes.Reader into a new slice inside
encnoding/binary.Read, and then finally copying it into the message.

With this change, a sub-slice of bytes from the network connection is
copied direclty into the parsed message. In our setup, this change
resulted in reducing CPU utilization from 220% to 15% (as reported by
`$ top`).

To make this possible, a new implementation of io.Reader is used that
acts like bytes.Reader, but also provides Next(n int) method that
returns a subslice of next N bytes without copying them, similarly to
bytes.Buffer. Unlike bytes.Buffer, this reader does not alter underlying
storage.

Drawbacks of this change:
 - Existing messages need to be regenerated because this commit changes
   ros.Message interface; might not be really an issue depending on
   build systems in use; I used Blaze (our internal version of Bazel),
   and we always regenerate messages.
 - Bytes deserialized from network connection will be kept around until
   the message is garbage collected.  And since only byte arrays use
   underlying bytes and other fields still copy data, this change
   increases overall memory footprint of deserialized messages. For
   images, this concern is negligible, since memory footprint is
   dominated by the image bytes, and storing metadata in memory twice
   does not appear to be an issue.

Limitations:
 - This only handles dynamic-size byte arrays. Fixed-size arrays could
   be handled in a similar fashion, but I didn't want to complicate
   message genration template too much.

Possible future optimizations to message deserialization:
 - All integral-typed arrays can benefit from decoding directly into
   them as a whole, rather than element-by-element. This will avoid
   allocating small slices for each element in encoding/binary.Read.
 - Strings can be treated in the same way as byte arrays.
 - On little-endian systems, use of unsafe package may allow for
   complete no-copy message deserialzation.